### PR TITLE
Added missing attrs on business repsonse model

### DIFF
--- a/lib/yelp/responses/models/business.rb
+++ b/lib/yelp/responses/models/business.rb
@@ -10,7 +10,8 @@ module Yelp
       class Business < Response::Base
         attr_reader :categories, :deals, :display_phone, :distance, :eat24_url, :gift_certificates, :id, :image_url,
                     :is_claimed, :is_closed, :location, :menu_provider, :menu_date_updated, :mobile_url, :name, :phone,
-                    :rating, :reviews, :reservation_url, :review_count, :snippet_image_url, :snippet_text, :url
+                    :rating, :reviews, :reservation_url, :review_count, :snippet_image_url, :snippet_text, :url,
+                    :rating_img_url, :rating_img_url_large, :rating_img_url_small
 
         def initialize(json)
           super(json)


### PR DESCRIPTION
It appears that the business response model was missing the following attrs:
`:rating_img_url_large`
`:rating_img_url_small`
`:rating_img_url`
